### PR TITLE
Bypass the error hasOwnProperty is not a function

### DIFF
--- a/hooks/lib/configXmlParser.js
+++ b/hooks/lib/configXmlParser.js
@@ -51,7 +51,7 @@ function readPreferences(cordovaContext) {
 // region Private API
 
 function getTeamIdPreference(xmlPreferences) {
-  if (xmlPreferences.hasOwnProperty('ios-team-id')) {
+  if (Object.prototype.hasOwnProperty.call(xmlPreferences, 'ios-team-id')) {
     return xmlPreferences['ios-team-id'][0]['$']['value'];
   }
 


### PR DESCRIPTION
Bypass the error hasOwnProperty is not a function